### PR TITLE
[docs] add model_name to OpenAI models YAML snippet (fixes #925)

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -134,6 +134,7 @@ Let's say OpenAI have just released the `gpt-3.5-turbo-0613` model and you want 
 
 ```yaml
 - model_id: gpt-3.5-turbo-0613
+  model_name: gpt-3.5-turbo-0613
   aliases: ["0613"]
 ```
 The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model.


### PR DESCRIPTION
Fixes #925

Adds required `model_name` key to example YAML snippet in [OpenAI models > Adding more OpenAI models](https://llm.datasette.io/en/stable/openai-models.html#adding-more-openai-models)